### PR TITLE
Catch unwind

### DIFF
--- a/agent/agent_config.yml
+++ b/agent/agent_config.yml
@@ -1,4 +1,5 @@
 # machine_identifier: name_of_this_machine
+max_panics: 1
 receptor:
     host: 127.0.0.1
     port: 1478

--- a/agent/plugins/src/plugin_initialization.rs
+++ b/agent/plugins/src/plugin_initialization.rs
@@ -3,8 +3,19 @@ macro_rules! plugins {
         $(extern crate $x;)*
 
         pub fn init() -> Vec<Box<AgentPlugin>> {
+            use std::panic;
             let mut v: Vec<Box<AgentPlugin>> = vec!();
-            $(v.push(Box::new($x::new()));)*
+            let p = panic::take_hook();
+            panic::set_hook(Box::new(|_info| {
+                // do nothing
+            }));
+            $(
+                match std::panic::catch_unwind(|| $x::new()) {
+                    Ok(x) => {v.push(Box::new(x))},
+                    Err(_) => { }
+                };
+            )*
+            panic::set_hook(p);
             v
         }
     }


### PR DESCRIPTION
This PR is for me to track agent robustness, and 'rubber duck' some ideas to myself.

TODO:

- [ ] Convert plugin::new() to return a result, and enforce as such in plugins!
  * let p: Result<$x::type, ????> = $x::new()
- [ ] Figure out what the error type of plugin::new() should be. Experiment with Failure. Maybe coerce into &Display?
- [ ] Wrap all plugin calls in std::panic::catch_unwind
- [ ] Figure out what to do with panic hooks. Show panic messages or not?
- [ ] Implement max_panics to allow plugins to panic some number of times
- [ ] Figure out how to drop plugins from the agent if they panic too often
- [ ] Figure out how to warn receptor of plugin failures
  * Write to log file, have plugin that ready() when log has content, gather() reads and clears file?